### PR TITLE
fix(cheerio): Fixed replaceing images in non XML compatible documents

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,11 +100,7 @@ export default function AdaptiveImages (options) {
   }
 
   function replaceMatchingImages (file) {
-    const $ = cheerio.load(file.contents, {
-      xmlMode: true,
-      lowerCaseTags: true,
-      lowerCaseAttributeNames: true
-    })
+    const $ = cheerio.load(file.contents)
 
     $(options.htmlImageSelector).map((index, img) => {
       const { src, ...attrs } = img.attribs


### PR DESCRIPTION
- XHTML is not widely spread
- HTML formatting could better done with the beautify plugin